### PR TITLE
Added MaintenanceMonitor.java and MaintenanceMonitorController.java Classes

### DIFF
--- a/src/main/java/at/fhtw/maintenancemonitor/MaintenanceMonitor.java
+++ b/src/main/java/at/fhtw/maintenancemonitor/MaintenanceMonitor.java
@@ -1,0 +1,26 @@
+package at.fhtw.maintenancemonitor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class MaintenanceMonitor {
+    private final String defaultStatus= "Everything works  as expected";
+    private String status = defaultStatus;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public ResponseEntity<String> setStatus(String setStatus) {
+        this.status = setStatus;
+        return new ResponseEntity<>("OK", HttpStatus.OK);
+    }
+
+    public ResponseEntity<String> resetStatus() {
+        this.status = defaultStatus;
+        return new ResponseEntity<>("OK", HttpStatus.OK);
+    }
+
+    public MaintenanceMonitor() {
+    }
+}

--- a/src/main/java/at/fhtw/maintenancemonitor/MaintenanceMonitorController.java
+++ b/src/main/java/at/fhtw/maintenancemonitor/MaintenanceMonitorController.java
@@ -1,0 +1,25 @@
+package at.fhtw.maintenancemonitor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class MaintenanceMonitorController {
+
+    private final MaintenanceMonitor monitor = new MaintenanceMonitor();
+
+    @GetMapping("/api/message")
+    public String message(){
+        return monitor.getStatus();
+    }
+
+    @RequestMapping("/api/message/set")
+    public ResponseEntity<String> setMonitorStatus(@RequestParam String statusMessage) {
+        return monitor.setStatus(statusMessage);
+    }
+
+    @RequestMapping("/api/message/reset")
+    public ResponseEntity<String> resetMonitorStatus() {
+        return monitor.resetStatus();
+    }
+}


### PR DESCRIPTION
MaintenanceMonitor.java:
- setStatus Method which sets an entered String as Monitor Status.
- resetStatus Method which resets the entered Monitor Status to pre defined String.
- getStatus to show the actual Monitor Status on the Client.
- MaintenanceMonitor constructor.

MaintenanceMonitorController.java:
- message Method which is mapped to /api/message it returns the Status and shows it in Client.
- setMonitorStatus Method which is mapped to /apo/message/set it request a String as input and will hand it over to the setStatus method. It will set a new Monitor Status.
- resetMonitorStatus Method which is mapped to /api/message/reset will reset the entered String to the pre defined default Monitor Status.